### PR TITLE
feat: minimum componentize changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,13 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
             COMMAND ${WASM_OPT} --strip-debug -O3 -o starling.wasm starling.wasm
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
+elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    add_custom_command(
+            TARGET starling.wasm
+            POST_BUILD
+            COMMAND ${WASM_OPT} -O3 -o starling.wasm starling.wasm
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
 endif()
 
 

--- a/builtins/web/console.cpp
+++ b/builtins/web/console.cpp
@@ -407,6 +407,7 @@ JS::Result<mozilla::Ok> ToSource(JSContext *cx, std::string &sourceOut, JS::Hand
 
 namespace builtins::web::console {
 
+__attribute__((weak))
 void builtin_impl_console_log(Console::LogType log_ty, const char *msg) {
   const char *prefix = "";
   switch (log_ty) {

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -54,7 +54,7 @@ public:
    * Get the JS value associated with the top-level script execution -
    * the last expression for a script, or the module namespace for a module.
    */
-  JS::PersistentRootedObject script_value();
+  HandleObject script_value();
 
   bool has_pending_async_tasks();
   void queue_async_task(AsyncTask *task);

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -50,6 +50,12 @@ public:
 
   bool run_event_loop(MutableHandleValue result);
 
+  /**
+   * Get the JS value associated with the top-level script execution -
+   * the last expression for a script, or the module namespace for a module.
+   */
+  JS::PersistentRootedObject script_value();
+
   bool has_pending_async_tasks();
   void queue_async_task(AsyncTask *task);
   bool cancel_async_task(int32_t id);

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -54,7 +54,7 @@ public:
    * Get the JS value associated with the top-level script execution -
    * the last expression for a script, or the module namespace for a module.
    */
-  HandleObject script_value();
+  HandleValue script_value();
 
   bool has_pending_async_tasks();
   void queue_async_task(AsyncTask *task);

--- a/runtime/allocator.cpp
+++ b/runtime/allocator.cpp
@@ -5,7 +5,7 @@ JSContext *CONTEXT = nullptr;
 
 extern "C" {
 
-__attribute__((export_name("cabi_realloc"))) void *cabi_realloc(void *ptr, size_t orig_size,
+__attribute__((weak, export_name("cabi_realloc"))) void *cabi_realloc(void *ptr, size_t orig_size,
                                                                 size_t _align, size_t new_size) {
   if (new_size == orig_size) {
     return ptr;

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -343,7 +343,7 @@ void api::Engine::enable_module_mode(bool enable) {
 }
 
 JS::PersistentRootedObject SCRIPT_VALUE;
-JS::PersistentRootedObject api::Engine::script_value() {
+HandleObject api::Engine::script_value() {
   return SCRIPT_VALUE;
 }
 

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -342,8 +342,8 @@ void api::Engine::enable_module_mode(bool enable) {
   scriptLoader->enable_module_mode(enable);
 }
 
-JS::PersistentRootedObject SCRIPT_VALUE;
-HandleObject api::Engine::script_value() {
+JS::PersistentRootedValue SCRIPT_VALUE;
+HandleValue api::Engine::script_value() {
   return SCRIPT_VALUE;
 }
 
@@ -351,12 +351,12 @@ void api::Engine::abort(const char *reason) { ::abort(CONTEXT, reason); }
 
 bool api::Engine::eval_toplevel(const char *path, MutableHandleValue result) {
   JSContext *cx = CONTEXT;
-  if (!scriptLoader->load_top_level_script(path, result)) {
+  RootedValue ns(cx);
+  if (!scriptLoader->load_top_level_script(path, &ns)) {
     return false;
   }
-  if (result.isObject()) {
-    SCRIPT_VALUE.init(cx, JS::RootedObject(cx, &result.toObject()));
-  }
+
+  SCRIPT_VALUE.init(cx, ns);
 
   // Ensure that any pending promise reactions are run before taking the
   // snapshot.

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -342,12 +342,20 @@ void api::Engine::enable_module_mode(bool enable) {
   scriptLoader->enable_module_mode(enable);
 }
 
+JS::PersistentRootedObject SCRIPT_VALUE;
+JS::PersistentRootedObject api::Engine::script_value() {
+  return SCRIPT_VALUE;
+}
+
 void api::Engine::abort(const char *reason) { ::abort(CONTEXT, reason); }
 
 bool api::Engine::eval_toplevel(const char *path, MutableHandleValue result) {
   JSContext *cx = CONTEXT;
   if (!scriptLoader->load_top_level_script(path, result)) {
     return false;
+  }
+  if (result.isObject()) {
+    SCRIPT_VALUE.init(cx, JS::RootedObject(cx, &result.toObject()));
   }
 
   // Ensure that any pending promise reactions are run before taking the

--- a/runtime/script_loader.cpp
+++ b/runtime/script_loader.cpp
@@ -69,14 +69,14 @@ static bool load_script(JSContext *cx, const char *script_path, const char* reso
 
 static JSObject* get_module(JSContext* cx, const char* specifier, const char* resolved_path,
                             const JS::CompileOptions &opts) {
-  RootedString resolve_path_str(cx, JS_NewStringCopyZ(cx, resolved_path));
-  if (!resolve_path_str) {
+  RootedString resolved_path_str(cx, JS_NewStringCopyZ(cx, resolved_path));
+  if (!resolved_path_str) {
     return nullptr;
   }
 
   RootedValue module_val(cx);
-  RootedValue resolve_path_val(cx, StringValue(resolve_path_str));
-  if (!JS::MapGet(cx, moduleRegistry, resolve_path_val, &module_val)) {
+  RootedValue resolved_path_val(cx, StringValue(resolved_path_str));
+  if (!JS::MapGet(cx, moduleRegistry, resolved_path_val, &module_val)) {
     return nullptr;
   }
 
@@ -100,13 +100,13 @@ static JSObject* get_module(JSContext* cx, const char* specifier, const char* re
     return nullptr;
   }
 
-  if (!JS_DefineProperty(cx, info, "path", resolve_path_val, JSPROP_ENUMERATE)) {
+  if (!JS_DefineProperty(cx, info, "path", resolved_path_val, JSPROP_ENUMERATE)) {
     return nullptr;
   }
 
   SetModulePrivate(module, ObjectValue(*info));
 
-  if (!MapSet(cx, moduleRegistry, resolve_path_val, module_val)) {
+  if (!MapSet(cx, moduleRegistry, resolved_path_val, module_val)) {
     return nullptr;
   }
 

--- a/runtime/script_loader.cpp
+++ b/runtime/script_loader.cpp
@@ -46,7 +46,7 @@ static const char* strip_base(const char* resolved_path, const char* base) {
   return buf;
 }
 
-static char* resolve_path(const char* path, const char* base) {
+static char* resolve_path(const char* path, const char* base, size_t base_len) {
   MOZ_ASSERT(base);
   if (path[0] == '/') {
     return strdup(path);
@@ -54,7 +54,6 @@ static char* resolve_path(const char* path, const char* base) {
   if (path[0] == '.' && path[1] == '/') {
     path = path + 2;
   }
-  size_t base_len = strlen(base);
   while (base_len > 0 && base[base_len - 1] != '/') {
     base_len--;
   }
@@ -140,10 +139,8 @@ JSObject* module_resolve_hook(JSContext* cx, HandleValue referencingPrivate,
     return nullptr;
   }
 
-  RootedString parent_path(cx, parent_path_val.toString());
-
   HostString str = core::encode(cx, parent_path_val);
-  char* resolved_path = resolve_path(path.get(), str.ptr.get());
+  char* resolved_path = resolve_path(path.get(), str.ptr.get(), str.len);
   return get_module(cx, path.get(), resolved_path, opts);
 }
 
@@ -198,7 +195,7 @@ static bool load_script(JSContext *cx, const char *specifier, const char* resolv
 
 bool ScriptLoader::load_script(JSContext *cx, const char *script_path,
                                JS::SourceText<mozilla::Utf8Unit> &script) {
-  auto resolved_path = resolve_path(script_path, BASE_PATH);
+  auto resolved_path = resolve_path(script_path, BASE_PATH, strlen(BASE_PATH));
   return ::load_script(cx, script_path, resolved_path, script);
 }
 


### PR DESCRIPTION
This is the bare minimum changes I need to get ComponentizeJS to work on top of StarlingMonkey.

* `cabi_realloc` as a weak symbol so it can be overridden to support the bulk deallocation strategy we use
* A new `script_value()` on the engine, allowing to get the value of the top-level script. For a script it would be the last statement value, and for a module it is defined to be the module namespace itself.
* Allowing the console `console_builtin_log` to be overridable as a weak symbol
* Supporting cycles in the script loader (since ComponentizeJS has a cycle with its bindings module)
* Removing the full path in the debug logs for script errors, showing only the base-path-relative filename
* Fixing relative resolution to be parent-relative always
* Adding support for `RelWithDebInfo` build target

I kept it to the bare minimum to avoid too much design discussion and just get a prototype together.

Feedback welcome.